### PR TITLE
add compatibility for Symfony > 3.1

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -33,13 +33,13 @@
         </service>
 
         <service id="acseo.form.extension.help" class="%acseo_dynamic_form.form.extension.help.class%">
-            <tag name="form.type_extension" alias="form"/>
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
         <service id="acseo.form.extension.picto" class="%acseo_dynamic_form.form.extension.picto.class%">
-            <tag name="form.type_extension" alias="form"/>
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
         <service id="acseo.form.extension.popin" class="%acseo_dynamic_form.form.extension.popin.class%">
-            <tag name="form.type_extension" alias="form"/>
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
         <service id="acseo.form.array.provider" class="%acseo_dynamic_form.array_form_provider.class%">

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": ">=2.0.0"        
+        "symfony/symfony": "~3.1"
     },
     "suggest": {
 
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3-dev"
+            "dev-master": "3.1-dev"
         }
     }
 }


### PR DESCRIPTION
This PR fix the error since Symfony 3.1 :

> "form.type_extension" tagged services must have the extended type configured using the extended_type/extended-type attribute, none was configured for the "acseo.form.extension.help" service.