### PR TITLE
fix incompatibility extension

### DIFF
--- a/Form/Extension/FieldTypeHelpExtension.php
+++ b/Form/Extension/FieldTypeHelpExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class FieldTypeHelpExtension

--- a/Form/Extension/FieldTypePictoExtension.php
+++ b/Form/Extension/FieldTypePictoExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class FieldTypePictoExtension

--- a/Form/Extension/FieldTypePopinExtension.php
+++ b/Form/Extension/FieldTypePopinExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 
 /**


### PR DESCRIPTION
fix the error : 

> Declaration of ACSEO\Bundle\DynamicFormBundle\Form\Extension\FieldTypePictoExtension::configureOptions(ACSEO\Bundle\DynamicFormBundle\Form\Extension\OptionsResolver $resolver) must be compatible with Symfony\Component\Form\FormTypeExtensionInterface::configureOptions(Symfony\Component\OptionsResolver\OptionsResolver $resolver)